### PR TITLE
Add Email Link Domain to constants in settings.py

### DIFF
--- a/server/ahj-registry-api/settings.py
+++ b/server/ahj-registry-api/settings.py
@@ -208,6 +208,7 @@ EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_PORT = 587
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_LINK_DOMAIN = 'localhost:8000' # Public domain name for including links to the AHJ Registry in an email
 
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True

--- a/server/core/models.py
+++ b/server/core/models.py
@@ -401,7 +401,7 @@ def send_user_confirmation_email(user):
     subject = 'AHJ Registry - Activate your account'
     message = render_to_string('acc_active_email.html', {
         'user': user,
-        'domain': 'localhost:8000',
+        'domain': settings.EMAIL_LINK_DOMAIN,
         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
         'token': user.email_confirmation_token.make_token(user)
     })
@@ -414,7 +414,7 @@ def send_edit_confirmation_email(user, edit):
     subject = 'AHJ Registry - An edit was submitted.'
     message = render_to_string('confirm_reject_edit_email.html', {
         'user': user,
-        'domain': 'localhost:8000',
+        'domain': settings.EMAIL_LINK_DOMAIN,
         'uid': urlsafe_base64_encode(force_bytes(user.pk)),
         'token': user.email_confirmation_token.make_token(user),
         'edit': edit,


### PR DESCRIPTION
There are two methods in core/models.py that send emails to AHJ Registry users that contain links back to the AHJ Registry. The domains of these links should be changeable in the settings.py file for deployment.