### PR TITLE
Fixed public api geo endpoints on invalid input

### DIFF
--- a/server/ahj_app/tests/constants.py
+++ b/server/ahj_app/tests/constants.py
@@ -1,0 +1,32 @@
+webpageTokenUrls= [ 
+    ('ahj-private', {}),
+    ('single_ahj', {}),
+    ('ahj-set-maintainer', {}), 
+    ('ahj-remove-maintainer', {}), 
+    ('edit-list', {}),
+    ('create-api-token', {}), 
+    ('edit-review', {}), 
+    ('edit-update', {}), 
+    ('edit-deletion', {}), 
+    ('edit-addition', {}),
+    ('user-create', {}),
+    ('user-login', {}),
+    ('user-logout', {}),
+    ('user-update', {'username':'test'}), 
+    ('user-edits', {}), 
+    ('user-comments', {}),
+    ('single-user-info', {'username': 'test'}), 
+    ('comment-submit', {}), 
+    ('data-map', {}), 
+    ('data-map-polygon', {}), 
+    ('form-validator', {}), 
+    ('user-create', {}), 
+    ('user-login', {}),
+    ('user-logout', {}),
+]
+
+apiTokenUrls = [
+    ('ahj-public', {}), 
+    ('ahj-geo-address', {}), 
+    ('ahj-geo-location', {}), 
+]

--- a/server/ahj_app/tests/fixtures.py
+++ b/server/ahj_app/tests/fixtures.py
@@ -1,0 +1,96 @@
+from django.urls import reverse, resolve
+from django.contrib.gis.db import models
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from django.contrib.gis.geos import Polygon as geosPolygon
+from ahj_app.models import WebpageToken, APIToken, User, Contact, Address, AHJ, AHJUserMaintains, Polygon
+from rest_framework.test import APIClient
+from constants import webpageTokenUrls, apiTokenUrls
+import datetime
+import pytest
+import random
+import string
+import uuid
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def create_user(db, django_user_model):
+    def make_user(**kwargs):
+        kwargs['password'] = 'strong-test-pass'
+        # If any required field missing, generate it here
+        if 'Username' not in kwargs or kwargs['Username'] is None:
+            kwargs['Username'] = str(uuid.uuid4())
+        if 'Email' not in kwargs or kwargs['Email'] is None:
+            kwargs['Email'] = random_char(5) + '@gmail.com'
+        user = django_user_model.objects.create_user(**kwargs)
+        User.objects.filter(UserID=user.UserID).update(is_active = True)
+        return user
+    return make_user
+
+@pytest.fixture
+def client_with_credentials(db, create_user, api_client):
+   user = create_user()
+   api_client.force_authenticate(user=user)
+   yield api_client
+   api_client.force_authenticate(user=None)
+
+@pytest.fixture
+def client_with_webpage_credentials(db, create_user, api_client):
+   user = create_user()
+   #User.objects.filter(UserID=user.UserID).update(is_active = True)
+   token = WebpageToken.objects.create(user=user)
+   api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+   return api_client
+
+@pytest.fixture
+def generate_client_with_webpage_credentials(db, create_user, api_client):
+    def generate_client(**kwargs):
+        username = kwargs.pop('Username', None)
+        email = kwargs.pop('Email', None)
+        user = create_user(Username=username, Email=email)
+        #User.objects.filter(UserID=user.UserID).update(is_active = True)
+        token = WebpageToken.objects.create(user=user)
+        api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        return api_client
+    return generate_client
+
+@pytest.fixture
+def client_with_api_credentials(db, create_user, api_client):
+   user = create_user()
+   #User.objects.filter(UserID=user.UserID).update(is_active = True)
+   token = APIToken.objects.create(user=user)
+   api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+   return api_client
+
+@pytest.fixture
+def generate_client_with_api_credentials(db, create_user, api_client):
+    def generate_client(**kwargs):
+        username = kwargs.pop('Username', None)
+        email = kwargs.pop('Email', None)
+        user = create_user(Username=username, Email=email)
+        #User.objects.filter(UserID=user.UserID).update(is_active = True)
+        token = APIToken.objects.create(user=user)
+        api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        return api_client
+    return generate_client
+
+@pytest.fixture
+def ahj_obj(db):
+    p1 = geosPolygon( ((0, 0), (0, 1), (1, 1), (0, 0)) )
+    p2 = geosPolygon( ((1, 1), (1, 2), (2, 2), (1, 1)) )
+    mp = MultiPolygon(p1, p2)
+    polygon = Polygon.objects.create(Polygon=mp, LandArea=1, WaterArea=1, InternalPLatitude=1, InternalPLongitude=1)
+    address = Address.objects.create()
+    ahj = AHJ.objects.create(AHJPK=1, PolygonID=polygon, AddressID=address)
+    return ahj 
+
+
+"""
+    Fixture helper methods
+"""
+
+def random_char(y):
+    return ''.join(random.choice(string.ascii_letters) for x in range(y))

--- a/server/ahj_app/tests/test_ahjsearch_views.py
+++ b/server/ahj_app/tests/test_ahjsearch_views.py
@@ -1,0 +1,73 @@
+from django.db import connection
+from django.urls import reverse
+from django.http import HttpRequest
+from ahj_app.models import User, Edit, Comment
+from ahj_app.models_field_enums import *
+from fixtures import *
+from ahj_app.utils import *
+import pytest
+import datetime
+import requests
+
+"""
+    Only Public AHJ Search Tests
+"""
+@pytest.mark.django_db
+def test_ahj_geo_address__missing_address(client_with_credentials):
+    url = reverse('ahj-geo-address')
+    response = client_with_credentials.post(url)
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_ahj_geo_address__invalid_address(client_with_credentials):
+    url = reverse('ahj-geo-address')
+    response = client_with_credentials.post(url, {'Address': {'AddrLine1': {'Value': '112 Baker St'}, 'AddrLine3': {''}}}, format='json')
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_ahj_geo_address__valid_address_format(client_with_credentials):
+    url = reverse('ahj-geo-address')
+    response = client_with_credentials.post(url, {'AddrLine1': {'Value': '112 Baker St'}, 'City': {'Value': 'Salt Lake City'}}, format='json')
+    assert response.status_code == 200
+    response = client_with_credentials.post(url, {'Address': {'AddrLine1': {'Value': '112 Baker St'}, 'City': {'Value': 'Salt Lake City'}}}, format='json')
+    assert response.status_code == 200
+
+@pytest.mark.django_db
+def test_ahj_geo_address__both_params_with_outdated_address_format(client_with_credentials):
+    url = reverse('ahj-geo-address')
+    response = client_with_credentials.post(url, {'ahjs_to_search': ['ID1', 'ID2'], 'AddrLine1': {'Value': '112 Baker St'}, 'City': {'Value': 'Salt Lake City'}}, format='json')
+    assert response.status_code == 200
+
+@pytest.mark.django_db
+def test_ahj_geo_address__both_params(client_with_credentials):
+    url = reverse('ahj-geo-address')
+    response = client_with_credentials.post(url, {'ahjs_to_search': ['ID1', 'ID2'], 'Address': {'AddrLine1': {'Value': '112 Baker St'}}}, format='json')
+    assert response.status_code == 200
+
+@pytest.mark.django_db
+def test_ahj_geo_location__valid_location_format(client_with_credentials):
+    url = reverse('ahj-geo-location')
+    response = client_with_credentials.post(url, { 'Latitude': { 'Value': '25' }, 'Longitude': { 'Value': '25' }}, format='json')
+    assert response.status_code == 200
+    response = client_with_credentials.post(url, {'Location': { 'Latitude': { 'Value': '25' }, 'Longitude': { 'Value': '25' }}}, format='json')
+    assert response.status_code == 200
+
+@pytest.mark.django_db
+def test_ahj_geo_location__missing_lat_or_long(client_with_credentials):
+    url = reverse('ahj-geo-location')
+    response = client_with_credentials.post(url, {'Location': { 'Latitude': { 'Value': '25' }}}, format='json')
+    assert response.status_code == 400
+    response = client_with_credentials.post(url, {'Location': {'Longitude': { 'Value': '25' }}}, format='json')
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_ahj_geo_location__missing_location(client_with_credentials):
+    url = reverse('ahj-geo-location')
+    response = client_with_credentials.post(url)
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_ahj_geo_location__invalid_location_format(client_with_credentials):
+    url = reverse('ahj-geo-location')
+    response = client_with_credentials.post(url, {'Location': {'Latitude': '25', 'Longitude': '25'}}, format='json')
+    assert response.status_code == 400

--- a/server/ahj_app/tests/test_ahjsearch_views.py
+++ b/server/ahj_app/tests/test_ahjsearch_views.py
@@ -9,6 +9,165 @@ import pytest
 import datetime
 import requests
 
+@pytest.fixture
+def ahj_filter_location():
+    return 'POINT(25, 25)'
+
+@pytest.fixture
+def empty_request_obj():
+    request = HttpRequest()
+    request.data = {}
+    return request
+
+@pytest.fixture
+def ahj_filter_polygon():
+    mp = MultiPolygon(geosPolygon(((0, 1), (0, 12), (10, 12), (10, 1), (0, 1))))
+    return get_multipolygon_wkt(mp)
+
+def ahj_filter_create_ahj(ahjpk, ahjid, polygonTuple, ahjLevel, AHJCode, BuildingCode=None, ElectricCode=None, AHJName=None):
+    p1 = geosPolygon(polygonTuple)
+    mp = MultiPolygon(p1)
+    polygon = Polygon.objects.create(Polygon=mp, LandArea=1, WaterArea=1, InternalPLatitude=1, InternalPLongitude=1)
+    address = Address.objects.create()
+    ahj = AHJ.objects.create(AHJPK=ahjpk, AHJID= ahjid, AHJCode=AHJCode, PolygonID=polygon, AddressID=address, AHJLevelCode=ahjLevel, BuildingCode=BuildingCode, ElectricCode=ElectricCode, AHJName=AHJName)
+    StatePolygon.objects.create(PolygonID=polygon)
+    return ahj
+
+@pytest.fixture
+def list_of_ahjs():
+    ahjLevel1 = AHJLevelCode.objects.create(AHJLevelCodeID=1, Value=AHJ_LEVEL_CODE_CHOICES[0][0])
+    ahjLevel2 = AHJLevelCode.objects.create(AHJLevelCodeID=2, Value=AHJ_LEVEL_CODE_CHOICES[1][0])
+    ahjLevel3 = AHJLevelCode.objects.create(AHJLevelCodeID=3, Value=AHJ_LEVEL_CODE_CHOICES[2][0])
+    buildingCode = BuildingCode.objects.create(BuildingCodeID=1, Value=BUILDING_CODE_CHOICES[0][0])
+    buildingCode2 = BuildingCode.objects.create(BuildingCodeID=2, Value=BUILDING_CODE_CHOICES[1][0])
+    electricCode = ElectricCode.objects.create(ElectricCodeID=1, Value=ELECTRIC_CODE_CHOICES[0][0])
+
+    ahj1 = ahj_filter_create_ahj(1, 'ID1', ((0, 0), (0, 10), (10, 10), (10, 0), (0,0)), ahjLevel1, 'Code1', buildingCode2, AHJName='AHJ 1') # AHJs 1 and 2 are in the same polygon as ahj_filter_polygon
+    ahj2 = ahj_filter_create_ahj(2, 'f97ea81a-f9c4-4195-889e-ad414b736ce5', ((0, 3), (0, 13), (10, 13), (10, 3), (0, 3)), ahjLevel2, 'CA-0686300', AHJName='Orange County' )
+    ahj3 = ahj_filter_create_ahj(3, 'ID3', ((20, 20), (20, 30), (30, 30), (30, 20), (20,20)), ahjLevel3, 'UT-0681820', AHJName='AHJ 3') # AHJ 3's polygon is over ahj_filter_location
+
+    ahj4 = ahj_filter_create_ahj(4, 'ID4', ((100, 100), (100, 110), (110, 110), (110, 100), (100, 100)), ahjLevel1, 'Code 4', buildingCode, electricCode, AHJName='AHJ 4') # AHJ 4 and 5 are found through the request 
+    ahj5 = ahj_filter_create_ahj(5, 'ID5', ((100, 100), (100, 110), (110, 110), (110, 100), (100, 100)), ahjLevel1, 'Code 5', buildingCode, electricCode, AHJName='AHJ 5')
+    return ahj1, ahj2, ahj3, ahj4, ahj5
+
+"""
+    Public and Private AHJ Search Tests
+"""
+
+@pytest.mark.parametrize(
+   'url_name', [
+       ('ahj-private'),
+       ('ahj-public')
+   ])
+@pytest.mark.django_db
+def test_webpage_ahj_list__no_search_parameters(url_name, client_with_credentials, list_of_ahjs):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url)
+    assert response.data['count'] == 5 # returns all 5 AHJs due to no filtering
+
+@pytest.mark.parametrize(
+   'url_name, payload', [
+       ('ahj-private', {'AHJName': 'Orange County'}),
+       ('ahj-public', {'AHJName': { 'Value': 'Orange County'}})
+   ])
+@pytest.mark.django_db
+def test_ahj_list__AHJName_search(url_name, payload, list_of_ahjs, ahj_filter_polygon, client_with_credentials):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url, payload, format='json')
+    assert response.data['count'] == 1 
+    if url_name == 'ahj-public': assert response.data['AuthorityHavingJurisdictions'][0]['AHJCode']['Value'] == 'CA-0686300' # verify only the ahj2 was returned
+    else: assert response.data['results']['ahjlist'][0]['AHJCode']['Value'] == 'CA-0686300'
+    
+
+@pytest.mark.parametrize(
+   'url_name, payload', [
+       ('ahj-private', {'AHJID': 'f97ea81a-f9c4-4195-889e-ad414b736ce5'}),
+       ('ahj-public', {'AHJID': {'Value': 'f97ea81a-f9c4-4195-889e-ad414b736ce5'}})
+   ])
+@pytest.mark.django_db
+def test_ahj_list__AHJID_search(url_name, payload, list_of_ahjs, ahj_filter_polygon, client_with_credentials):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url, payload, format='json')
+    assert response.data['count'] == 1 
+    if url_name == 'ahj-public': assert response.data['AuthorityHavingJurisdictions'][0]['AHJCode']['Value'] == 'CA-0686300' # verify only the ahj2 was returned
+    else: assert response.data['results']['ahjlist'][0]['AHJCode']['Value'] == 'CA-0686300'
+
+@pytest.mark.parametrize(
+   'url_name, payload', [
+       ('ahj-private', {'AHJCode': 'CA-0686300'}),
+       ('ahj-public', {'AHJCode': {'Value': 'CA-0686300'}})
+   ])
+@pytest.mark.django_db
+def test_ahj_list__AHJCode_search(url_name, payload, list_of_ahjs, ahj_filter_polygon, client_with_credentials):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url, payload, format='json')
+    assert response.data['count'] == 1 
+    if url_name == 'ahj-public': assert response.data['AuthorityHavingJurisdictions'][0]['AHJCode']['Value'] == 'CA-0686300' # verify only the ahj2 was returned
+    else: assert response.data['results']['ahjlist'][0]['AHJCode']['Value'] == 'CA-0686300'
+
+@pytest.mark.parametrize(
+   'url_name, payload', [
+       ('ahj-private', {'AHJLevelCode': '040'}),
+       ('ahj-public', {'AHJLevelCode': {'Value': '040'}})
+   ])
+@pytest.mark.django_db
+def test_ahj_list__AHJLevelCode_search(url_name, payload, list_of_ahjs, client_with_credentials):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url, payload, format='json')
+    assert response.data['count'] == 3
+
+@pytest.mark.parametrize(
+   'url_name, payload', [
+       ('ahj-private', {'AHJLevelCode': '040'}),
+       ('ahj-public', {'AHJLevelCode': {'Value': '040'}})
+   ])
+@pytest.mark.django_db
+def test_ahj_list__AHJLevelCode_search(url_name, payload, list_of_ahjs, client_with_credentials):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url, payload, format='json')
+    assert response.data['count'] == 3
+
+@pytest.mark.parametrize(
+   'url_name, payload', [
+       ('ahj-private', { "BuildingCode": [ "2021IBC" ],  "ElectricCode": [  "2020NEC"  ]}),
+       ('ahj-public', { 'BuildingCodes': [ { 'Value': '2021IBC'} ],  'ElectricCodes': [  { 'Value':'2020NEC'}  ]})
+   ])
+@pytest.mark.django_db
+def test_ahj_list__BuildingCode_search(url_name, payload, list_of_ahjs, client_with_credentials):
+    ahj1, ahj2, ahj3, ahj4, ahj5 = list_of_ahjs
+    url = reverse(url_name)
+    response = client_with_credentials.post(url, payload, format='json')
+    assert response.data['count'] == 2 
+
+"""
+    Only Private AHJ Search Tests
+"""
+@pytest.mark.django_db
+def test_get_single_ahj__valid_ahj(ahj_obj, client_with_credentials):
+    url = reverse('single_ahj')
+    response = client_with_credentials.get(url, {'AHJPK': ahj_obj.AHJPK})
+    assert len(response.data) == 1
+    assert response.data[0]['AHJPK']['Value'] == ahj_obj.AHJPK
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+   'param', [
+       ({}),
+       ({'AHJPK': 2}),
+   ]
+)
+def test_get_single_ahj__incorrect_param(param, ahj_obj, client_with_credentials):
+    url_name = reverse('single_ahj')
+    response = client_with_credentials.get(url_name, param)
+    assert len(response.data) == 0
+    assert response.status_code == 200
+
 """
     Only Public AHJ Search Tests
 """
@@ -53,7 +212,19 @@ def test_ahj_geo_location__valid_location_format(client_with_credentials):
     assert response.status_code == 200
 
 @pytest.mark.django_db
-def test_ahj_geo_location__missing_lat_or_long(client_with_credentials):
+def test_ahj_geo_location__empty_lat_lon(client_with_credentials):
+    url = reverse('ahj-geo-location')
+    response = client_with_credentials.post(url, {'Location': { 'Latitude': { 'Value': '' }, 'Longitude': { 'Value': '' }}}, format='json')
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_ahj_geo_location__invalid_values_lat_lon(client_with_credentials):
+    url = reverse('ahj-geo-location')
+    response = client_with_credentials.post(url, {'Location': { 'Latitude': { 'Value': 'a' }, 'Longitude': { 'Value': 'a' }}}, format='json')
+    assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_ahj_geo_location__missing_lat_or_lon(client_with_credentials):
     url = reverse('ahj-geo-location')
     response = client_with_credentials.post(url, {'Location': { 'Latitude': { 'Value': '25' }}}, format='json')
     assert response.status_code == 400

--- a/server/ahj_app/urls.py
+++ b/server/ahj_app/urls.py
@@ -3,10 +3,10 @@ from . import views_ahjsearch, views_ahjsearch_api, views_users, views_misc, vie
 
 
 urlpatterns = [
-    path('ahj/',                          views_ahjsearch_api.ahj_list,          name='ahj'),
-    path('ahj-private/',                  views_ahjsearch.webpage_ahj_list,      name='ahj'),
-    path('geo/address/',                  views_ahjsearch_api.ahj_geo_address,   name='ahj'),
-    path('geo/location/',                 views_ahjsearch_api.ahj_geo_location,  name='ahj'),
+    path('ahj/',                          views_ahjsearch_api.ahj_list,          name='ahj-public'),
+    path('ahj-private/',                  views_ahjsearch.webpage_ahj_list,      name='ahj-private'),
+    path('geo/address/',                  views_ahjsearch_api.ahj_geo_address,   name='ahj-geo-address'),
+    path('geo/location/',                 views_ahjsearch_api.ahj_geo_location,  name='ahj-geo-location'),
     path('ahj-one/',                      views_ahjsearch.get_single_ahj,        name='single_ahj'),
     path('ahj/set-maintainer/',           views_users.set_ahj_maintainer,        name='ahj-maintainer'),
     path('ahj/remove-maintainer/',        views_users.remove_ahj_maintainer,     name='ahj-maintainer'),

--- a/server/ahj_app/utils.py
+++ b/server/ahj_app/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
@@ -21,9 +22,12 @@ def get_ob_value_primitive(ob_json, field_name, throw_exception=True, exception_
             return values
         return ob_json[field_name]['Value']
     except (TypeError, KeyError):
-        if throw_exception:
+        if throw_exception and field_name in ob_json: # Throws exception if the json had the key but it was not in correct OB format
             raise ValueError(f'Missing \'Value\' key for Orange Button field \'{field_name}\'')
-        return exception_return_value
+        return exception_return_value # returns empty string if the json didn't have the field name as a key
+    
+def check_address_empty(address):
+    return re.search('[a-zA-Z0-9]', address) # If number or letter exists, then at least one address field has been provided
 
 
 def get_str_location(location):
@@ -38,13 +42,13 @@ def get_str_location(location):
 
 def get_str_address(address):
     return \
-        get_ob_value_primitive(address, 'AddrLine1', throw_exception=False, exception_return_value='') + ' ' + \
-        get_ob_value_primitive(address, 'AddrLine2', throw_exception=False, exception_return_value='') + ' ' + \
-        get_ob_value_primitive(address, 'AddrLine3', throw_exception=False, exception_return_value='') + ', ' + \
-        get_ob_value_primitive(address, 'City', throw_exception=False, exception_return_value='') + ' ' + \
-        get_ob_value_primitive(address, 'County', throw_exception=False, exception_return_value='') + ' ' + \
-        get_ob_value_primitive(address, 'StateProvince', throw_exception=False, exception_return_value='') + ' ' + \
-        get_ob_value_primitive(address, 'ZipPostalCode', throw_exception=False, exception_return_value='')
+        get_ob_value_primitive(address, 'AddrLine1', exception_return_value='') + ' ' + \
+        get_ob_value_primitive(address, 'AddrLine2', exception_return_value='') + ' ' + \
+        get_ob_value_primitive(address, 'AddrLine3', exception_return_value='') + ', ' + \
+        get_ob_value_primitive(address, 'City', exception_return_value='') + ' ' + \
+        get_ob_value_primitive(address, 'County', exception_return_value='') + ' ' + \
+        get_ob_value_primitive(address, 'StateProvince', exception_return_value='') + ' ' + \
+        get_ob_value_primitive(address, 'ZipPostalCode', exception_return_value='')
 
 
 def get_location_gecode_address_str(address):
@@ -190,7 +194,7 @@ def get_multipolygon_wkt(multipolygon):
 
 
 def filter_ahjs(AHJName=None, AHJID=None, AHJPK=None, AHJCode=None, AHJLevelCode=None,
-                BuildingCode=None, ElectricCode=None, FireCode=None, ResidentialCode=None, WindCode=None,
+                BuildingCode=[], ElectricCode=[], FireCode=[], ResidentialCode=[], WindCode=[],
                 StateProvince=None, location=None, polygon=None):
     """
     Main Idea: This functional view uses raw SQL queries to
@@ -305,7 +309,7 @@ def filter_ahjs(AHJName=None, AHJID=None, AHJPK=None, AHJCode=None, AHJLevelCode
 
 def order_ahj_list_AHJLevelCode_PolygonLandArea(ahj_list):
     ahj_list.sort(key=lambda ahj: int(ahj.PolygonID.LandArea) if ahj.PolygonID is not None else 0) # Sort first by landarea ascending
-    ahj_list.sort(reverse=True, key=lambda ahj: int(ahj.AHJLevelCode) if ahj.AHJLevelCode != '' else 0) # Then sort by numerical value AHJLevelCode descending
+    ahj_list.sort(reverse=True, key=lambda ahj: int(ahj.AHJLevelCode.Value) if ahj.AHJLevelCode is not None else 0) # Then sort by numerical value AHJLevelCode descending
     return ahj_list
 
 

--- a/server/ahj_app/views_ahjsearch_api.py
+++ b/server/ahj_app/views_ahjsearch_api.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from .authentication import APITokenAuth
 from .serializers import AHJSerializer
 from .utils import order_ahj_list_AHJLevelCode_PolygonLandArea, filter_ahjs, get_str_location, \
-    get_public_api_serializer_context, get_ob_value_primitive, get_str_address, get_location_gecode_address_str
+    get_public_api_serializer_context, get_ob_value_primitive, get_str_address, get_location_gecode_address_str, check_address_empty
 
 
 @api_view(['POST'])
@@ -87,6 +87,8 @@ def ahj_geo_location(request):
 
     try:
         str_location = get_str_location(ob_location)
+        if (str_location == None):
+            return Response('Location field(s) cannot be empty.', status=status.HTTP_400_BAD_REQUEST)
     except (TypeError, KeyError, ValueError) as e:
         return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
 
@@ -113,7 +115,9 @@ def ahj_geo_address(request):
 
     try:
         str_address = get_str_address(ob_address)
-    except TypeError:
+        if (check_address_empty(str_address) == None):
+            return Response('Address field(s) cannot be empty.', status=status.HTTP_400_BAD_REQUEST)
+    except Exception:
         return Response('Invalid Address, all values must be strings', status=status.HTTP_400_BAD_REQUEST)
 
     ob_location = get_location_gecode_address_str(str_address)

--- a/server/pytest.ini
+++ b/server/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = TheAHJRegistry.settings
+addopts = --reuse-db


### PR DESCRIPTION
- ahj_geo_address and ahj_geo_location endpoints now handle invalid inputs correctly both for invalid OB structure and missing parameters.
- included pytest unit/integration tests for the ahj search endpoints