### PR TITLE
Fixed edit old value not storing properly

### DIFF
--- a/server/ahj_app/views_edits.py
+++ b/server/ahj_app/views_edits.py
@@ -245,6 +245,8 @@ def edit_update(request):
 
                 if e['SourceColumn'] in ENUM_FIELDS and old_value is None:
                     e['OldValue'] = ''
+                elif e['SourceColumn'] in ENUM_FIELDS:
+                    e['OldValue'] = old_value.Value
                 else:
                     e['OldValue'] = old_value
 


### PR DESCRIPTION
Storing the old value for an edit would store the stringified version of an enum object ("ResidentialCode object (2)" for example) instead of storing the actual value ("2009 IRC").