### PR TITLE
Adding Django endpoint 'docs/' linking to Sphinx documentation, fixing tests

### DIFF
--- a/client/src/components/Navbar.vue
+++ b/client/src/components/Navbar.vue
@@ -16,7 +16,8 @@
         <b-nav-item href="#/ahj-search">Search</b-nav-item>
         <b-nav-item href="#/data-vis">Coverage</b-nav-item>
         <b-nav-item href="#/ahj-search/?tutorial=1">Tutorial</b-nav-item>
-        <b-nav-item v-b-modal.my-modal @click='ResetFeedbackForm'>Help</b-nav-item> 
+        <b-nav-item :href="DocumentationLink" target="_blank">Documentation</b-nav-item>
+        <b-nav-item v-b-modal.my-modal @click='ResetFeedbackForm'>Help</b-nav-item>
         <feedback-form ref="feedbackFormComponent"></feedback-form>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto navbar-background">
@@ -56,6 +57,7 @@
 
 <script>
 import FeedbackForm from "../components/FeedbackForm.vue";
+import constants from "../constants";
 export default {
   model: {
     event: 'event-open-modal'
@@ -69,6 +71,9 @@ export default {
     },
     Username() {
       return this.$store.getters.currentUserInfo ? this.$store.getters.currentUserInfo.Username : "";
+    },
+    DocumentationLink() {
+      return constants.DOCS_ENDPOINT;
     }
   },
   methods: {

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,9 +1,12 @@
-const API_ENDPOINT = "http://localhost:8000/api/v1/";
+const API_DOMAIN = "http://localhost:8000/"
+const API_ENDPOINT = `${API_DOMAIN}api/v1/`;
+const DOCS_ENDPOINT = `${API_DOMAIN}docs/`
 const SUPPORT_EMAIL = "support@sunspec.org";
 const MEMBERSHIP_EMAIL = "membership@sunspec.org";
 
 export default {
   API_ENDPOINT: API_ENDPOINT,
+  DOCS_ENDPOINT: DOCS_ENDPOINT,
   SUPPORT_EMAIL: SUPPORT_EMAIL,
   MEMBERSHIP_EMAIL: MEMBERSHIP_EMAIL,
   AHJ_FIELDS: {

--- a/server/TheAHJRegistry/settings.py
+++ b/server/TheAHJRegistry/settings.py
@@ -50,7 +50,8 @@ INSTALLED_APPS = [
     'ahj_app.apps.AhjConfig',
     'djoser',
     'corsheaders',
-    'simple_history'
+    'simple_history',
+    'docs'
 ]
 
 MIDDLEWARE = [
@@ -254,5 +255,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 STATIC_ROOT = 'static'
+
+DOCS_ROOT = os.path.join(BASE_DIR, '../docs/build/html')
 
 GOOGLE_MAPS_KEY = ''

--- a/server/TheAHJRegistry/urls.py
+++ b/server/TheAHJRegistry/urls.py
@@ -15,9 +15,10 @@ Examples:
         #. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('ahj_app.urls')),
+    re_path('docs/', include('docs.urls'))
 ]

--- a/server/ahj_app/tests/fixtures.py
+++ b/server/ahj_app/tests/fixtures.py
@@ -18,6 +18,14 @@ import uuid
 def api_client():
     return APIClient()
 
+
+def register_user_dict():
+    return {'FirstName': 'first', 'MiddleName': 'middle', 'LastName': 'last',
+            'Title': 'title', 'Email': 'email@email.email', 'WorkPhone': '123-456-7890',
+            'PreferredContactMethod': 'Email', 'ContactTimezone': 'PST',
+            'Username': 'username', 'password': '#$()asdf!@{}1'}
+
+
 @pytest.fixture
 def create_user(db, django_user_model):
     def make_user(**kwargs):
@@ -57,39 +65,29 @@ def client_with_credentials(db, create_user, api_client):
    api_client.force_authenticate(user=None)
 
 @pytest.fixture
-def client_with_webpage_credentials(db, create_user, api_client):
-   user = create_user()
-   token = WebpageToken.objects.create(user=user)
-   api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
-   return api_client
-
-@pytest.fixture
 def generate_client_with_webpage_credentials(db, create_user, api_client):
     def generate_client(**kwargs):
-        username = kwargs.pop('Username', None)
-        email = kwargs.pop('Email', None)
-        user = create_user(Username=username, Email=email)
+        user = create_user(**kwargs)
         token = WebpageToken.objects.create(user=user)
         api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
         return api_client
     return generate_client
 
 @pytest.fixture
-def client_with_api_credentials(db, create_user_with_active_api_token, api_client):
-   user = create_user_with_active_api_token()
-   api_client.credentials(HTTP_AUTHORIZATION='Token ' + user.api_token.key)
-   return api_client
+def client_with_webpage_credentials(db, generate_client_with_webpage_credentials):
+    return generate_client_with_webpage_credentials()
 
 @pytest.fixture
-def generate_client_with_api_credentials(db, create_user, api_client):
+def generate_client_with_api_credentials(db, create_user_with_active_api_token, api_client):
     def generate_client(**kwargs):
-        username = kwargs.pop('Username', None)
-        email = kwargs.pop('Email', None)
-        user = create_user(Username=username, Email=email)
-        token = APIToken.objects.create(user=user)
-        api_client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        user = create_user_with_active_api_token(**kwargs)
+        api_client.credentials(HTTP_AUTHORIZATION='Token ' + user.api_token.key)
         return api_client
     return generate_client
+
+@pytest.fixture
+def client_with_api_credentials(db, generate_client_with_api_credentials):
+    return generate_client_with_api_credentials()
 
 @pytest.fixture
 def ahj_obj(db):

--- a/server/ahj_app/tests/test_throttles.py
+++ b/server/ahj_app/tests/test_throttles.py
@@ -1,5 +1,5 @@
 from fixtures import *
-from ahj_app.models import SunspecAllianceMember, SunspecAllianceMemberDomain
+from ahj_app.models import SunspecAllianceMember, SunspecAllianceMemberDomain, User
 from django.urls import reverse
 import pytest
 from django.conf import settings
@@ -7,6 +7,7 @@ import random
 import string
 
 
+@pytest.fixture
 def generate_sunspec_alliance_member():
     letters = string.ascii_letters
     member = SunspecAllianceMember.objects.create(MemberName=''.join(random.choice(letters) for i in range(6)))
@@ -19,27 +20,46 @@ def generate_sunspec_alliance_member():
 """
 @pytest.mark.parametrize(
    'urlName, args', [
-       ('ahj-public', { 'Location': {'Longitude': { 'Value': 'hello' }, 'Latitude': { 'Value': 'hello' }}}), # pass invalid args to each so early exit
-       ('ahj-geo-address', {}),
-       ('ahj-geo-location', { 'Latitude': { 'V': '25' }}),
+       ('ahj-public', {'Location': {'Longitude': {'Value': -120}, 'Latitude': {'Value': 37}}}), # pass invalid args to each so early exit
+       ('ahj-geo-address', {'AddrLine1': {'Value': '1600 Pennsylvania Avenue NW'}, 'City': {'Value': 'Washington'}, 'County': {'Value': 'DC'}, 'StateProvince': {'Value': 'DC'}})
    ]
 )
 @pytest.mark.django_db
-def test_member_rate_throttle__regular_user(urlName, args, generate_client_with_api_credentials):
-    memberID, domain = generate_sunspec_alliance_member()
+def test_member_rate_throttle__regular_user(urlName, args, generate_client_with_api_credentials, generate_sunspec_alliance_member):
+    memberID, domain = generate_sunspec_alliance_member
     client = generate_client_with_api_credentials(Email=f'f@{domain}')
-    User.objects.filter(Email=f'f@{domain}').update(MemberID = memberID)
-
+    User.objects.filter(Email=f'f@{domain}').update(MemberID=memberID)
     url = reverse(urlName)
     # Test with a throttle rate that is less than actual (actual rate would take insanely long to test)
     iterNum = 5
-    settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['member'] = f'{iterNum}/day' 
-    for i in range(0, iterNum):
+    settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['member'] = f'{iterNum}/day'
+    for _ in range(iterNum):
         response = client.post(url, args, format='json')
-        # Check second to last run is not throttled
-        if (i == iterNum-1):
-            assert response.status_code != 429 # too many requests status code (throttled)
+        assert response.status_code == 200
     response = client.post(url, args, format='json')
+    assert response.status_code == 429
+    assert response.data['detail'][0:22] == 'Request was throttled.'
+
+@pytest.mark.parametrize(
+   'urlName, args', [
+       ('ahj-public', {'Location': {'Longitude': {'Value': 'hello'}, 'Latitude': {'Value': 'hello'}}}), # pass invalid args to each so early exit
+       ('ahj-geo-address', {}),
+       ('ahj-geo-location', {'Latitude': {'V': '25'}}),
+   ]
+)
+@pytest.mark.django_db
+def test_member_rate_throttle__regular_user_hits_throttle_with_bad_requests(urlName, args, generate_client_with_api_credentials, generate_sunspec_alliance_member):
+    memberID, domain = generate_sunspec_alliance_member
+    client = generate_client_with_api_credentials(Email=f'f@{domain}')
+    User.objects.filter(Email=f'f@{domain}').update(MemberID=memberID)
+    url = reverse(urlName)
+    iterNum = 5
+    settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['member'] = f'{iterNum}/day'
+    for _ in range(iterNum):
+        response = client.post(url, args, format='json')
+        assert response.status_code == 400
+    response = client.post(url, args, format='json')
+    assert response.status_code == 429
     assert response.data['detail'][0:22] == 'Request was throttled.'
 
 """
@@ -50,12 +70,11 @@ def test_webpage_search_throttle__anon_user(client_without_credentials):
     url = reverse('ahj-private')
     iterNum = 3
     settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['webpage-search'] = f'{iterNum}/day'
-    for i in range(0, iterNum):
+    for _ in range(iterNum):
         response = client_without_credentials.post(url, {}, format='json')
-        # Check second to last run is not throttled
-        if (i == iterNum-1):
-            assert response.status_code == 200
+        assert response.status_code == 200
     response = client_without_credentials.post(url, {}, format='json')
+    assert response.status_code == 429
     assert response.data['detail'][0:22] == 'Request was throttled.'
 
 @pytest.mark.django_db
@@ -64,26 +83,23 @@ def test_webpage_search_throttle__logged_in_user(generate_client_with_webpage_cr
     url = reverse('ahj-private')
     iterNum = 3
     settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['webpage-search'] = f'{iterNum}/day'
-    for i in range(0, iterNum):
+    for _ in range(iterNum):
         response = client.post(url, {}, format='json')
-        # Check second to last run is not throttled
-        if (i == iterNum-1):
-            assert response.status_code == 200     
+        assert response.status_code == 200
     response = client.post(url, {}, format='json')
+    assert response.status_code == 429
     assert response.data['detail'][0:22] == 'Request was throttled.'
 
 @pytest.mark.django_db
-def test_webpage_search_throttle__member_user(generate_client_with_webpage_credentials):
-    memberID, domain = generate_sunspec_alliance_member()
+def test_webpage_search_throttle__member_user_unlimited_requests(generate_client_with_webpage_credentials, generate_sunspec_alliance_member):
+    memberID, domain = generate_sunspec_alliance_member
     client = generate_client_with_webpage_credentials(Email=f'f@{domain}')
-    User.objects.filter(Email=f'f@{domain}').update(MemberID = memberID)
+    User.objects.filter(Email=f'f@{domain}').update(MemberID=memberID)
     url = reverse('ahj-private')
     iterNum = 3
     settings.REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['webpage-search'] = f'{iterNum}/day'
-    for i in range(0, iterNum):
+    for _ in range(iterNum):
         response = client.post(url, {}, format='json')
-        # Check second to last run is not throttled
-        if (i == iterNum-1):
-            assert response.status_code == 200
+        assert response.status_code == 200
     response = client.post(url, {}, format='json')
-    assert response.status_code == 200 # API calls still work outside of the throttle threshold (because members have unlimited calls)
+    assert response.status_code == 200

--- a/server/ahj_app/throttles.py
+++ b/server/ahj_app/throttles.py
@@ -87,6 +87,8 @@ class WebpageSearchThrottle(UserRateThrottle):
     
     def user_is_member(self, user):
         if user.is_authenticated:
-            if user.MemberID or user.get_API_token(): # Allows access if member OR if they have an API token
+            api_token = user.get_API_token()
+            has_active_api_token = api_token.is_active if api_token is not None else False
+            if user.MemberID or has_active_api_token:  # Allows access if member OR if they have an API token
                 return True                         
         return False                                

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,6 +13,7 @@ cryptography==3.3.1
 defusedxml==0.7.0rc2
 Django==3.1.3
 django-cors-headers==3.5.0
+django-docs==0.3.1
 django-filter==2.4.0
 django-request-logging==0.7.2
 django-simple-history==3.0.0


### PR DESCRIPTION
- Can now view generated Sphinx docs at https://<domain>/docs/
  - This uses a plugin called django-docs
- Link to Sphinx docs on NavBar
- Fixed bug in throttling
- Updated and refactored tests for views_users.py and throttles.py